### PR TITLE
refactor: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,26 +235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-flight"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1362a6a02e31734c67eb2e9a30dca1689d306cfe2fc00bc6430512091480ce"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-ipc",
- "arrow-schema",
- "base64 0.21.0",
- "bytes",
- "futures",
- "prost",
- "prost-derive",
- "tokio",
- "tonic",
-]
-
-[[package]]
 name = "arrow-ipc"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,9 +304,6 @@ name = "arrow-schema"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d04f17f7b86ded0b5baf98fe6123391c4343e031acc3ccc5fa604cc180bff220"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "arrow-select"
@@ -388,28 +356,6 @@ name = "async-recursion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.13",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -481,21 +427,6 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
 ]
 
 [[package]]
@@ -585,12 +516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
-name = "bytemuck"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,7 +598,6 @@ dependencies = [
  "iana-time-zone",
  "num-integer",
  "num-traits",
- "serde",
  "winapi",
 ]
 
@@ -912,7 +836,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
- "serde",
 ]
 
 [[package]]
@@ -1125,19 +1048,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1355,35 +1265,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "h2"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
 
 [[package]]
 name = "half"
@@ -1497,12 +1382,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,7 +1391,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1524,18 +1402,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1915,25 +1781,16 @@ dependencies = [
 
 [[package]]
 name = "newpromql"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "async-recursion",
- "async-trait",
- "bytemuck",
- "chrono",
  "datafusion",
- "futures",
  "md5",
  "promql-parser",
  "serde",
- "serde_json",
- "snafu",
  "strum",
  "strum_macros",
  "time",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2031,15 +1888,6 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2323,45 +2171,22 @@ dependencies = [
 
 [[package]]
 name = "prom_test_bin"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
- "anyhow",
  "arrow",
  "arrow-array",
- "arrow-flight",
- "arrow-schema",
- "async-recursion",
- "async-stream",
  "axum",
- "bytes",
- "chrono",
  "clap",
- "dashmap",
  "datafusion",
- "env_logger",
- "futures",
- "futures-util",
- "hyper",
- "lazy_static",
- "log",
  "newpromql",
- "parking_lot",
- "parquet",
- "paste",
  "promql-parser",
- "prost",
- "rand",
  "serde",
  "serde_json",
- "sqlparser",
- "tempfile",
  "time",
  "tokio",
- "tonic",
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
@@ -2375,29 +2200,6 @@ dependencies = [
  "lrlex",
  "lrpar",
  "regex",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2475,27 +2277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
-
-[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,27 +2306,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
-dependencies = [
- "base64 0.21.0",
 ]
 
 [[package]]
@@ -2580,16 +2340,6 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "semver"
@@ -2740,7 +2490,6 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
 dependencies = [
- "backtrace",
  "doc-comment",
  "snafu-derive",
 ]
@@ -2784,12 +2533,6 @@ dependencies = [
  "serde",
  "vob",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
@@ -3014,16 +2757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,17 +2765,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.13",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls",
- "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -3067,41 +2789,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "prost-derive",
- "rustls-pemfile",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -3112,13 +2799,9 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
- "slab",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3187,16 +2870,6 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -3295,12 +2968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,8 +2991,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
- "rand",
- "serde",
 ]
 
 [[package]]
@@ -3445,26 +3110,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "web-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.1"
+version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -7,15 +7,6 @@ license = "Apache-2.0"
 members = ["newpromql", "cmd"]
 
 [workspace.dependencies]
-async-trait = "0.1"
 datafusion = { version = "22" }
-datafusion-common = { version = "22" }
-datafusion-expr = { version = "22" }
-datafusion-optimizer = { version = "22" }
-datafusion-physical-expr = { version = "22" }
-datafusion-sql = { version = "22" }
-snafu = { version = "0.7", features = ["backtraces"] }
-tokio = { version = "1.24.2", features = ["full"] }
-tokio-util = "0.7"
-tracing = "0.1"
-tracing-subscriber = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+time = "0.3"

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -5,43 +5,17 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow = "1.0"
 arrow = { version = "36.0", features = ["simd", "ipc_compression"] }
 arrow-array = "36.0"
-arrow-flight = "36.0"
-arrow-schema = { version = "36.0", features = ["serde"] }
-async-recursion = "1.0"
-async-stream = "0.3"
-bytes = "1.4"
-chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "serde",
-] }
+axum = { version = "0.6", features = ["headers"] }
 clap = { version = "4.2", features = ["derive"] }
-dashmap = { version = "5.4.0", features = ["serde"] }
 datafusion.workspace = true
-env_logger = "0.10"
-futures = "0.3"
-futures-util = "0.3"
-lazy_static = "1.4"
-log = "0.4.17"
 newpromql = { path = "../newpromql" }
-parking_lot = "0.12"
-parquet = { version = "36.0", features = ["arrow", "async"] }
-paste = "1.0"
 promql-parser = "0.1"
-prost = "0.11"
-rand = "0.8"
-serde = { version = "1.0", features = ["derive"] }
+serde.workspace = true
 serde_json = "1.0"
-sqlparser = "0.32"
-tempfile = "3"
-time = "0.3.17"
-tokio.workspace = true
-tonic = { version = "0.8", features = ["tls"] }
-tracing.workspace = true
-tracing-subscriber.workspace = true
-uuid = { version = "1", features = ["serde", "v4", "fast-rng"] }
-axum = { version = "0.6.16", features = ["headers"] }
-hyper = { version = "0.14.26", features = ["full"] }
+time.workspace = true
+tokio = { version = "1.27", features = ["full"] }
 tower-http = { version = "0.4", features = ["trace"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/newpromql/Cargo.toml
+++ b/newpromql/Cargo.toml
@@ -6,21 +6,10 @@ license.workspace = true
 
 [dependencies]
 async-recursion = "1.0"
-async-trait.workspace = true
-bytemuck = "1.12"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
 datafusion.workspace = true
-futures = "0.3"
+md5 = "0.7"
 promql-parser = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
+serde.workspace = true
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
-time = "0.3.17"
-tracing.workspace = true
-tracing-subscriber.workspace = true
-md5 = "0.7"
-
-[dev-dependencies]
-tokio.workspace = true
+time.workspace = true

--- a/newpromql/src/value.rs
+++ b/newpromql/src/value.rs
@@ -1,13 +1,12 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub static _FIELD_NAME: &str = "__name__";
-pub static FIELD_HASH: &str = "__hash__";
-pub static FIELD_TYPE: &str = "metric_type";
-pub static FIELD_TIME: &str = "_timestamp";
-pub static FIELD_VALUE: &str = "value";
+pub const FIELD_HASH: &str = "__hash__";
+pub const FIELD_TYPE: &str = "metric_type";
+pub const FIELD_TIME: &str = "_timestamp";
+pub const FIELD_VALUE: &str = "value";
 
-type Metric = HashMap<String, String>;
+pub type Metric = HashMap<String, String>;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Sample {
@@ -39,7 +38,7 @@ pub enum Value {
 }
 
 impl Value {
-    pub fn is_empty(&self) -> bool {
+    pub fn is_none(&self) -> bool {
         matches!(self, Value::None)
     }
 


### PR DESCRIPTION
- Remove unused dependencies from `Cargo.toml` files.
- Extract common code into `micros_since_epoch` function.
- Use `try_into`, not `as`, when converting from `u128` to `i64`.